### PR TITLE
JankyScript: coercions now compile

### DIFF
--- a/libjankscripten/src/jankierscript/coercion_insertion.rs
+++ b/libjankscripten/src/jankierscript/coercion_insertion.rs
@@ -30,8 +30,8 @@ impl Typing {
             Stmt::Var(x, t, e) => {
                 match t {
                     Some(Type::Any) => {
-                        let (e, t) = self.insert_coercions_expr(e, env)?;
-                        Ok(Janky_::var_(&x, t, e))
+                        let (e, t) = self.insert_coercions_expr(*e, env)?;
+                        Ok(Janky_::var_(x, t, e))
                     },
                     _ => unimplemented!()
                 }
@@ -39,18 +39,18 @@ impl Typing {
             Stmt::Block(stmts) => self.insert_coercions_stmts(stmts, env),
             Stmt::If(c, t, e) => {
                 // coerce the conditional expression into type Bool
-                let c = self.coerce_expr(*c, Type::Bool, env)?;
+                let c = self.coerce_expr(*c, Type::Bool, env.clone())?;
 
                 // coerce the two branches and put it all together
                 Ok(Janky_::if_(c,
-                    self.insert_coercions_stmt(*t, env)?,
-                    self.insert_coercions_stmt(*e, env)?
+                    self.insert_coercions_stmt(*t, env.clone())?,
+                    self.insert_coercions_stmt(*e, env.clone())?
                 ))
             }
             Stmt::While(cond, body) => {
                 // coerce the loop conditional into type Bool
-                let cond = self.coerce_expr(*cond, Type::Bool, env)?;
-                let body = self.insert_coercions_stmt(*body, env)?;
+                let cond = self.coerce_expr(*cond, Type::Bool, env.clone())?;
+                let body = self.insert_coercions_stmt(*body, env.clone())?;
                 Ok(Janky_::while_(cond, body))
             }
             Stmt::Empty => Ok(Janky_::empty_()),
@@ -108,9 +108,9 @@ impl Typing {
         }
     }
 
-    fn insert_coercions_lit(&self, lit: Lit) -> TypingResult<(Janky::Lit, Type)> {
+    fn insert_coercions_lit(&self, lit: Janky::Lit) -> TypingResult<(Janky::Lit, Type)> {
         match lit {
-            Lit::Num(n) => Ok((Janky_::num_(&n), Type::Float)),
+            Janky::Lit::Num(n) => Ok((Janky_::num_(n), Type::Float)),
             _ => unimplemented!()
         }
     }

--- a/libjankscripten/src/jankierscript/mod.rs
+++ b/libjankscripten/src/jankierscript/mod.rs
@@ -2,5 +2,5 @@
 mod syntax;
 // pub mod constructors;
 // pub mod inference;
-// pub mod coercion_insertion;
+pub mod coercion_insertion;
 pub mod from_javascript;

--- a/libjankscripten/src/jankyscript/constructors.rs
+++ b/libjankscripten/src/jankyscript/constructors.rs
@@ -5,8 +5,8 @@ use crate::shared::ops::*;
 
 // Lit
 
-pub fn num_(n: &str) -> Lit {
-    Lit::Num(n.to_string())
+pub fn num_(n: Num) -> Lit {
+    Lit::Num(n)
 }
 
 // Expressions
@@ -23,10 +23,10 @@ pub fn coercion_(c: Coercion, e: Expr) -> Expr {
     Expr::Coercion(c, Box::new(e))
 }
 
-// Statments
+// Statements
 
-pub fn var_(x: &str, t: Type, e: Expr) -> Stmt {
-    Stmt::Var(x.to_string(), t, e)
+pub fn var_(x: Id, t: Type, e: Expr) -> Stmt {
+    Stmt::Var(x, t, e)
 }
 
 pub fn block_(stmts: Vec<Stmt>) -> Stmt {

--- a/libjankscripten/src/jankyscript/mod.rs
+++ b/libjankscripten/src/jankyscript/mod.rs
@@ -1,4 +1,4 @@
 pub mod syntax;
-// pub mod constructors;
+pub mod constructors;
 
 //pub mod type_checking;

--- a/libjankscripten/src/jankyscript/syntax.rs
+++ b/libjankscripten/src/jankyscript/syntax.rs
@@ -1,37 +1,13 @@
 //! The JankierScript language
 
+use crate::shared::coercions::Coercion;
 use crate::shared::types::Type;
 use crate::shared::ops::*;
 
 pub type Id = super::super::javascript::Id;
 pub type Lit = super::super::javascript::Lit;
+pub type Num = super::super::javascript::Num;
 pub type Key = super::super::javascript::Key;
-
-#[derive(Debug)]
-/// Coercion : S -> T
-/// 
-/// Every coercion turns into a call to a function in the runtime system.
-pub enum Coercion {
-    /// Coercion::Tag(t) : t -> Any
-    /// Note that not all values may be injected in Any.
-    Tag(Type),
-    /// Coercion::Untag(t) : Any -> t
-    /// Note that untagging will fail if the Any-typed value contains an element
-    /// that does not have the type t.
-    Untag(Type),
-    /// Coercion::Fun(args, ret)
-    /// 
-    /// Assume exactly one argument:
-    /// 
-    /// Coercion::Fun([arg], ret) where arg : S -> S' and ret : T -> T'
-    /// Coercion::Fun([arg], ret) : (S' -> T) -> (S -> T')
-    Fun(Vec<Coercion>, Box<Coercion>),
-    // Coercion::Id(t) : t -> t
-    Id(Type),
-    /// Coercion::Seq(t2, t1) where t1 : S -> U and t2 : U -> T
-    /// has the type S -> Ts
-    Seq(Box<Coercion>, Box<Coercion>)
-}
 
 #[derive(Debug)]
 pub enum LValue {


### PR DESCRIPTION
the modules are now actually imported, so they are typechecked too.

in addition, i removed a duplicate type definition of Coercion. the same
definition of Coercions existed both in JankyScript and the `shared`
module. i removed the JankyScript version, since it only had
dependencies on `shared` types.