### PR TITLE
Add many binary/unary operators needed by java

### DIFF
--- a/integration_tests/test_data/abstract_eq.js
+++ b/integration_tests/test_data/abstract_eq.js
@@ -1,0 +1,7 @@
+// let's do T-F every other
+// TODO(luna): strings, once they work elsewhere because i don't know if
+// the problem is in strings or in eq
+log_any(void 0 == null);
+log_any(null == 5);
+log_any(3.0 == 3);
+log_any(true == false);

--- a/integration_tests/test_data/abstract_eq.txt
+++ b/integration_tests/test_data/abstract_eq.txt
@@ -1,0 +1,4 @@
+Bool(true)
+Bool(false)
+Bool(true)
+Bool(false)

--- a/libjankscripten/src/jankyscript/syntax.rs
+++ b/libjankscripten/src/jankyscript/syntax.rs
@@ -15,24 +15,15 @@ pub type UnaryOp = super::super::notwasm::syntax::UnaryOp;
 
 impl BinaryOp {
     pub fn janky_typ(self: &BinaryOp) -> (Type, Type) {
+        use super::super::notwasm::syntax::BinaryOp::*;
         match self {
-            BinaryOp::PtrEq => (Type::Any, Type::Bool), // for completeness; should be special-cased
-            BinaryOp::I32Eq
-            | BinaryOp::I32GT
-            | BinaryOp::I32LT
-            | BinaryOp::I32Ge
-            | BinaryOp::I32Le => (Type::Int, Type::Bool),
-            BinaryOp::F64Eq | BinaryOp::F64LT => (Type::Float, Type::Bool),
-            BinaryOp::I32Add
-            | BinaryOp::I32Sub
-            | BinaryOp::I32Mul
-            | BinaryOp::I32Div
-            | BinaryOp::I32Rem
-            | BinaryOp::I32And
-            | BinaryOp::I32Or => (Type::Int, Type::Int),
-            BinaryOp::F64Add | BinaryOp::F64Sub | BinaryOp::F64Mul | BinaryOp::F64Div => {
-                (Type::Float, Type::Float)
+            PtrEq => (Type::Any, Type::Bool), // for completeness; should be special-cased
+            I32Eq | I32Ne | I32GT | I32LT | I32Ge | I32Le => (Type::Int, Type::Bool),
+            F64Eq | F64Ne | F64LT | F64GT | F64Ge | F64Le => (Type::Float, Type::Bool),
+            I32Add | I32Sub | I32Mul | I32Div | I32Rem | I32And | I32Or | I32Shl | I32Shr => {
+                (Type::Int, Type::Int)
             }
+            F64Add | F64Sub | F64Mul | F64Div => (Type::Float, Type::Float),
         }
     }
 }
@@ -42,6 +33,7 @@ impl UnaryOp {
         match self {
             UnaryOp::Sqrt => (Type::Float, Type::Float),
             UnaryOp::Neg => (Type::Float, Type::Float),
+            UnaryOp::Eqz => (Type::Bool, Type::Bool),
         }
     }
 }

--- a/libjankscripten/src/notwasm/pretty.rs
+++ b/libjankscripten/src/notwasm/pretty.rs
@@ -60,6 +60,7 @@ impl Pretty for UnaryOp {
         match self {
             UnaryOp::Sqrt => pp.text("Math.sqrt"),
             UnaryOp::Neg => pp.text("-"),
+            UnaryOp::Eqz => pp.text("!"),
         }
     }
 }
@@ -74,6 +75,7 @@ impl Pretty for BinaryOp {
         match self {
             BinaryOp::PtrEq => pp.text("==="),
             BinaryOp::I32Eq => pp.text("==="),
+            BinaryOp::I32Ne => pp.text("!="),
             BinaryOp::I32Add => pp.text("+"),
             BinaryOp::I32Sub => pp.text("-"),
             BinaryOp::I32Mul => pp.text("*"),
@@ -85,12 +87,18 @@ impl Pretty for BinaryOp {
             BinaryOp::I32Or => pp.text("|"),
             BinaryOp::I32Div => pp.text("/"),
             BinaryOp::I32Rem => pp.text("%"),
+            BinaryOp::I32Shl => pp.text("<<"),
+            BinaryOp::I32Shr => pp.text(">>"),
             BinaryOp::F64Eq => pp.text("==="),
+            BinaryOp::F64Ne => pp.text("!="),
             BinaryOp::F64Add => pp.text("+"),
             BinaryOp::F64Sub => pp.text("-"),
             BinaryOp::F64Mul => pp.text("*"),
             BinaryOp::F64Div => pp.text("/"),
             BinaryOp::F64LT => pp.text("<"),
+            BinaryOp::F64GT => pp.text(">"),
+            BinaryOp::F64Le => pp.text("<="),
+            BinaryOp::F64Ge => pp.text(">="),
         }
     }
 }

--- a/libjankscripten/src/notwasm/syntax.rs
+++ b/libjankscripten/src/notwasm/syntax.rs
@@ -85,27 +85,36 @@ pub struct FnType {
 /// Binary operators that correspond to primitive WebAssembly instructions.
 /// Other than `PtrEq`, none of these operators can be applied to `Any`-typed
 /// values.
+///
+/// Note that all I32s are signed in jankyscript
 #[derive(Clone, Debug, PartialEq)]
 pub enum BinaryOp {
     PtrEq,
     I32Eq,
+    I32Ne,
     I32Add,
     I32Sub,
     I32Mul,
     I32Div,
     I32Rem,
-    I32GT, // signed
-    I32LT, // signed
-    I32Ge, // signed
-    I32Le, // signed
+    I32GT,
+    I32LT,
+    I32Ge,
+    I32Le,
     I32And,
     I32Or,
+    I32Shl,
+    I32Shr,
     F64Add,
     F64Sub,
     F64Mul,
     F64Div,
     F64Eq,
+    F64Ne,
     F64LT,
+    F64Le,
+    F64GT,
+    F64Ge,
 }
 
 impl BinaryOp {
@@ -122,6 +131,7 @@ impl BinaryOp {
 pub enum UnaryOp {
     Sqrt,
     Neg,
+    Eqz,
 }
 
 impl UnaryOp {

--- a/libjankscripten/src/notwasm/translation.rs
+++ b/libjankscripten/src/notwasm/translation.rs
@@ -460,32 +460,41 @@ impl<'a> Translate<'a> {
     }
 
     fn translate_binop(&mut self, op: &N::BinaryOp) {
+        use N::BinaryOp as NO;
         match op {
-            N::BinaryOp::PtrEq => self.out.push(I32Eq),
-            N::BinaryOp::I32Eq => self.out.push(I32Eq),
-            N::BinaryOp::I32Add => self.out.push(I32Add),
-            N::BinaryOp::I32Sub => self.out.push(I32Sub),
-            N::BinaryOp::I32GT => self.out.push(I32GtS),
-            N::BinaryOp::I32LT => self.out.push(I32LtS),
-            N::BinaryOp::I32Ge => self.out.push(I32GeS),
-            N::BinaryOp::I32Le => self.out.push(I32LeS),
-            N::BinaryOp::I32Mul => self.out.push(I32Mul),
-            N::BinaryOp::I32Div => self.out.push(I32DivS),
-            N::BinaryOp::I32Rem => self.out.push(I32RemS),
-            N::BinaryOp::I32And => self.out.push(I32And),
-            N::BinaryOp::I32Or => self.out.push(I32Or),
-            N::BinaryOp::F64Add => self.out.push(F64Add),
-            N::BinaryOp::F64Sub => self.out.push(F64Sub),
-            N::BinaryOp::F64Mul => self.out.push(F64Mul),
-            N::BinaryOp::F64Div => self.out.push(F64Div),
-            N::BinaryOp::F64LT => self.out.push(F64Lt),
-            N::BinaryOp::F64Eq => self.out.push(F64Eq),
+            NO::PtrEq => self.out.push(I32Eq),
+            NO::I32Eq => self.out.push(I32Eq),
+            NO::I32Ne => self.out.push(I32Ne),
+            NO::I32Add => self.out.push(I32Add),
+            NO::I32Sub => self.out.push(I32Sub),
+            NO::I32GT => self.out.push(I32GtS),
+            NO::I32LT => self.out.push(I32LtS),
+            NO::I32Ge => self.out.push(I32GeS),
+            NO::I32Le => self.out.push(I32LeS),
+            NO::I32Mul => self.out.push(I32Mul),
+            NO::I32Div => self.out.push(I32DivS),
+            NO::I32Rem => self.out.push(I32RemS),
+            NO::I32And => self.out.push(I32And),
+            NO::I32Or => self.out.push(I32Or),
+            NO::I32Shl => self.out.push(I32Shl),
+            NO::I32Shr => self.out.push(I32ShrS),
+            NO::F64Add => self.out.push(F64Add),
+            NO::F64Sub => self.out.push(F64Sub),
+            NO::F64Mul => self.out.push(F64Mul),
+            NO::F64Div => self.out.push(F64Div),
+            NO::F64LT => self.out.push(F64Lt),
+            NO::F64GT => self.out.push(F64Gt),
+            NO::F64Le => self.out.push(F64Le),
+            NO::F64Ge => self.out.push(F64Ge),
+            NO::F64Eq => self.out.push(F64Eq),
+            NO::F64Ne => self.out.push(F64Ne),
         }
     }
     fn translate_unop(&mut self, op: &N::UnaryOp) {
         match op {
             N::UnaryOp::Sqrt => self.out.push(F64Sqrt),
             N::UnaryOp::Neg => self.out.push(F64Neg),
+            N::UnaryOp::Eqz => self.out.push(I32Eqz),
         }
     }
 

--- a/libjankscripten/src/rts_function.rs
+++ b/libjankscripten/src/rts_function.rs
@@ -11,30 +11,46 @@ use strum_macros::EnumIter;
 #[derive(Debug, Clone, Copy, PartialEq, EnumIter)]
 pub enum RTSFunction {
     Todo(&'static str),
+    // ???
+    LogAny,
+    // unary ops
     Typeof,
     Delete,
+    Void,
+    // janky binops
     Plus,
+    Minus,
+    Times,
     Over,
     Mod,
     ModF64,
+    StrictEqual,
     Equal,
-    LogAny,
+    StrictNotEqual,
+    NotEqual,
 }
 
 impl RTSFunction {
     /// The name of a function in the runtime system. This is the name that the runtime  exports,
     /// using `[no_mangle]`.
     pub fn name(&self) -> &'static str {
+        use RTSFunction::*;
         match self {
-            RTSFunction::Todo(name) => todo!("unimplemented operator: {}", name),
-            RTSFunction::Typeof => "janky_typeof",
-            RTSFunction::Delete => "janky_delete",
-            RTSFunction::Plus => "janky_plus",
-            RTSFunction::Over => "janky_over",
-            RTSFunction::Mod => "janky_mod",
-            RTSFunction::ModF64 => "janky_mod_f64",
-            RTSFunction::Equal => "janky_equal",
-            RTSFunction::LogAny => "log_any",
+            Todo(name) => todo!("unimplemented operator: {}", name),
+            LogAny => "log_any",
+            Typeof => "janky_typeof",
+            Delete => "janky_delete",
+            Void => "janky_void",
+            Plus => "janky_plus",
+            Minus => "janky_minus",
+            Times => "janky_times",
+            Over => "janky_over",
+            Mod => "janky_mod",
+            ModF64 => "janky_mod_f64",
+            StrictEqual => "janky_strict_equal",
+            Equal => "janky_equal",
+            StrictNotEqual => "janky_strict_not_equal",
+            NotEqual => "janky_not_equal",
         }
     }
 
@@ -62,16 +78,19 @@ impl RTSFunction {
     ///
     /// That sentence makes me want to fall asleep.
     pub fn janky_typ(&self) -> Type {
+        use RTSFunction::*;
         match self {
-            RTSFunction::Todo(name) => todo!("unimplemented operator: {}", name),
-            RTSFunction::Typeof => Function(vec![Any], Box::new(String)),
-            RTSFunction::Delete => Function(vec![Any, Any], Box::new(Bool)),
-            RTSFunction::Plus => Function(vec![Any, Any], Box::new(Any)),
-            RTSFunction::Over => Function(vec![Any, Any], Box::new(Float)),
-            RTSFunction::Mod => Function(vec![Any, Any], Box::new(Any)),
-            RTSFunction::ModF64 => Function(vec![Float, Float], Box::new(Float)),
-            RTSFunction::Equal => Function(vec![Any, Any], Box::new(Bool)),
-            RTSFunction::LogAny => Function(vec![Any, Any], Box::new(Any)),
+            Todo(name) => todo!("unimplemented operator: {}", name),
+            LogAny => Function(vec![Any, Any], Box::new(Any)),
+            Typeof => Function(vec![Any], Box::new(String)),
+            Delete => Function(vec![Any, Any], Box::new(Bool)),
+            Void => Function(vec![Any], Box::new(Any)),
+            Plus | Minus | Times | Mod => Function(vec![Any, Any], Box::new(Any)),
+            Over => Function(vec![Any, Any], Box::new(Float)),
+            ModF64 => Function(vec![Float, Float], Box::new(Float)),
+            StrictEqual | Equal | StrictNotEqual | NotEqual => {
+                Function(vec![Any, Any], Box::new(Bool))
+            }
         }
     }
 }
@@ -84,14 +103,20 @@ impl std::fmt::Display for RTSFunction {
             "{}",
             match self {
                 Todo(s) => s,
+                LogAny => "logany",
                 Typeof => "typeof",
                 Delete => "delete",
+                Void => "void",
                 Plus => "+",
-                Over => "over",
+                Minus => "-",
+                Times => "*",
+                Over => "/",
                 Mod => "%",
-                ModF64 => "%64",
+                ModF64 => "%.",
+                StrictEqual => "===",
                 Equal => "==",
-                LogAny => "logany",
+                StrictNotEqual => "!==",
+                NotEqual => "!=",
             }
         )
     }

--- a/runtime/src/coercions.rs
+++ b/runtime/src/coercions.rs
@@ -1,0 +1,100 @@
+use crate::any_value::{AnyValue as Any, *};
+
+pub fn i32s_or_as_f64s<T, F, I>(a: Any, b: Any, floats: F, ints: I) -> Option<T>
+where
+    F: FnOnce(f64, f64) -> T,
+    I: FnOnce(i32, i32) -> T,
+{
+    match (*a, *b) {
+        (AnyEnum::F64(a), AnyEnum::F64(b)) => Some(floats(unsafe { *a }, unsafe { *b })),
+        (AnyEnum::I32(a), AnyEnum::F64(b)) => Some(floats(a as f64, unsafe { *b })),
+        (AnyEnum::F64(a), AnyEnum::I32(b)) => Some(floats(unsafe { *a }, b as f64)),
+        (AnyEnum::I32(a), AnyEnum::I32(b)) => Some(ints(a, b)),
+        _ => None,
+    }
+}
+
+pub fn i32s_or_as_f64s_any(
+    a: Any,
+    b: Any,
+    floats: fn(f64, f64) -> f64,
+    ints: fn(i32, i32) -> i32,
+) -> Option<Any> {
+    i32s_or_as_f64s(
+        a,
+        b,
+        |a, b| f64_to_any(floats(a, b)),
+        |a, b| any_from_i32(ints(a, b)),
+    )
+}
+
+/// adapted from https://ecma-international.org/ecma-262/5.1/#sec-11.9.3
+pub fn abstract_eq(a: AnyEnum, b: AnyEnum) -> bool {
+    use crate::HeapPtr;
+    // 1. same type
+    // number == number
+    if let Some(res) = i32s_or_as_f64s(a.into(), b.into(), |a, b| a == b, |a, b| a == b) {
+        return res;
+    }
+    // rest
+    match (a, b) {
+        (AnyEnum::Bool(a), AnyEnum::Bool(b)) => return a == b,
+        (AnyEnum::Ptr(a), AnyEnum::Ptr(b)) => match (a.view(), b.view()) {
+            (HeapRefView::String(a), HeapRefView::String(b)) => return a == b,
+            (HeapRefView::I32(a), b) | (b, HeapRefView::I32(a)) => {
+                return abstract_eq(AnyEnum::I32(*a), AnyEnum::Ptr(b.as_any_ptr()))
+            }
+            _ => todo!(),
+        },
+        (AnyEnum::StrPtr(a), AnyEnum::StrPtr(b)) => return a == b,
+        // when fns become closures they might need to gain an impl PartialEq
+        // which should only return true on pointer equality
+        (AnyEnum::Fn(a), AnyEnum::Fn(b)) => return a == b,
+        (AnyEnum::Undefined, AnyEnum::Undefined) => return true,
+        (AnyEnum::Null, AnyEnum::Null) => return true,
+        // not the same type. on to rule 2!
+        _ => (),
+    }
+    // even rules:
+    if let Some(res) = even_abstract_eq(a, b) {
+        res
+    // odd rules
+    } else if let Some(res) = even_abstract_eq(b, a) {
+        res
+    } else {
+        // 10
+        false
+    }
+}
+/// only implementing even numbered rules (not 10), then going to match on the reverse
+fn even_abstract_eq(a: AnyEnum, b: AnyEnum) -> Option<bool> {
+    Some(match (a, b) {
+        // 2
+        (AnyEnum::Null, AnyEnum::Undefined) => true,
+        // 4
+        (AnyEnum::I32(i), AnyEnum::StrPtr(s)) => {
+            i as f64 == <&str>::from(s).parse().unwrap_or(f64::NAN)
+        }
+        (AnyEnum::F64(f), AnyEnum::StrPtr(s)) => {
+            (unsafe { *f }) == <&str>::from(s).parse().unwrap_or(f64::NAN)
+        }
+        // rest of rules 4 and 8
+        (a, AnyEnum::Ptr(p)) => match p.view() {
+            // 4
+            HeapRefView::String(s) => match a {
+                AnyEnum::I32(i) => i as f64 == s.parse().unwrap_or(f64::NAN),
+                AnyEnum::F64(f) => (unsafe { *f }) == s.parse().unwrap_or(f64::NAN),
+                // presumably will be caught on the right side on the odd pass
+                _ => return None,
+            },
+            // 8
+            HeapRefView::I32(i) => abstract_eq(a, AnyEnum::I32(*i)),
+            // 8
+            _ => todo!("javascript spec ToPrimitive / DefaultValue"),
+        },
+        // 6
+        (AnyEnum::Bool(to_num), _) => abstract_eq(AnyEnum::I32(to_num as i32), b),
+        // onto odd rules!
+        _ => return None,
+    })
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,9 +23,11 @@ pub mod object;
 pub mod ops;
 pub mod r#ref; // Rust raw identifier syntax
 pub mod string;
-mod util;
 
 mod allocator;
+mod coercions;
+mod util;
+
 use crate::allocator::Tag;
 use allocator::*;
 use any_value::AnyEnum;


### PR DESCRIPTION
it's not necessarily all the binary operators needed for java, but it's all the
binary operators that come up before something else comes up while compiling

also, this includes abstract equality which was the hardest one, but it doesn't support all of it because that requires prototypes