### PR TITLE
Allow most benchmarks through jankyscript typecheck

### DIFF
--- a/libjankscripten/src/jankierscript/coercion_insertion.rs
+++ b/libjankscripten/src/jankierscript/coercion_insertion.rs
@@ -471,7 +471,7 @@ impl InsertCoercions {
                     // Bitwise not; needed for one particular dart benchmark
                     (UnaryOp::Tilde, _) => Ok((
                         Janky::Expr::PrimCall(
-                            RTSFunction::Todo("bitwise not"),
+                            RTSFunction::BitwiseNot,
                             vec![self.coerce(coerced_e, e_ty, Type::Int, s.clone())],
                             s,
                         ),
@@ -483,7 +483,15 @@ impl InsertCoercions {
                         Janky::Expr::PrimCall(
                             RTSFunction::Plus,
                             vec![
-                                Janky::Expr::Lit(Janky::Lit::Num(Janky::Num::Int(0)), s.clone()),
+                                self.coerce(
+                                    Janky::Expr::Lit(
+                                        Janky::Lit::Num(Janky::Num::Int(0)),
+                                        s.clone(),
+                                    ),
+                                    Type::Int,
+                                    Type::Any,
+                                    s.clone(),
+                                ),
                                 self.coerce(coerced_e, e_ty, Type::Any, s.clone()),
                             ],
                             s,

--- a/libjankscripten/src/jankierscript/coercion_insertion.rs
+++ b/libjankscripten/src/jankierscript/coercion_insertion.rs
@@ -153,6 +153,11 @@ fn binop_overload(op: &BinOp, lhs_ty: &Type, rhs_ty: &Type) -> TypeOverload {
         (BinOp::RightShift, _, _) => prim_same(BinaryOp::I32Shr, Int),
         (BinOp::InstanceOf, _, _) => rts(RTSFunction::InstanceOf, Bool),
         (BinOp::XOr, _, _) => prim_same(BinaryOp::I32Xor, Int),
+        // TODO(luna): this is very likely to produce values that are larger
+        // than signed 32-bit integers can hold. it should probably actually go to
+        // f64 which is awful but more correct
+        (BinOp::UnsignedRightShift, _, _) => prim_same(BinaryOp::I32ShrU, Int),
+        (BinOp::In, _, _) => rts(RTSFunction::In, Bool),
         (_, _, _) => (
             Overload::RTS(RTSFunction::Todo(Box::leak(Box::new(format!(
                 "unimplemented binop {:?} {:?} {:?}",
@@ -546,7 +551,7 @@ impl InsertCoercions {
                     )),
                     (UnaryOp::Delete, _) => Ok((
                         Janky::Expr::PrimCall(
-                            RTSFunction::Todo("delete"),
+                            RTSFunction::Delete,
                             vec![self.coerce(coerced_e, e_ty, Type::Any, s.clone())],
                             s,
                         ),

--- a/libjankscripten/src/jankierscript/coercion_insertion.rs
+++ b/libjankscripten/src/jankierscript/coercion_insertion.rs
@@ -191,6 +191,13 @@ impl InsertCoercions {
                 let body = self.stmt(*body, &mut env.clone(), ret_ty)?;
                 Ok(Janky_::loop_(body, s))
             }
+            Stmt::ForIn(bind, container, body, s) => {
+                // could be DynObject or Array
+                let container = self.expr(*container, Type::Any, &mut env.clone(), s.clone())?;
+                // new scope
+                let body = self.stmt(*body, &mut env.clone(), ret_ty)?;
+                Ok(Janky_::for_in_(bind, container, body, s))
+            }
             Stmt::Empty => Ok(Janky_::empty_()),
             Stmt::Expr(e, s) => {
                 // One of the few cases where the type does not matter

--- a/libjankscripten/src/jankierscript/coercion_insertion.rs
+++ b/libjankscripten/src/jankierscript/coercion_insertion.rs
@@ -152,6 +152,7 @@ fn binop_overload(op: &BinOp, lhs_ty: &Type, rhs_ty: &Type) -> TypeOverload {
         (BinOp::LeftShift, _, _) => prim_same(BinaryOp::I32Shl, Int),
         (BinOp::RightShift, _, _) => prim_same(BinaryOp::I32Shr, Int),
         (BinOp::InstanceOf, _, _) => rts(RTSFunction::InstanceOf, Bool),
+        (BinOp::XOr, _, _) => prim_same(BinaryOp::I32Xor, Int),
         (_, _, _) => (
             Overload::RTS(RTSFunction::Todo(Box::leak(Box::new(format!(
                 "unimplemented binop {:?} {:?} {:?}",

--- a/libjankscripten/src/jankierscript/constructors.rs
+++ b/libjankscripten/src/jankierscript/constructors.rs
@@ -1,13 +1,11 @@
 use super::syntax::*;
-use crate::shared::ops::BinOp;
-use crate::shared::types::Type;
+use crate::pos::Pos;
 
 // Expressions
 
 pub fn lit_(l: Lit, s: Pos) -> Expr {
     Expr::Lit(l, s)
 }
-
 pub fn binary_(op: BinOp, e1: Expr, e2: Expr, s: Pos) -> Expr {
     Expr::Binary(op, Box::new(e1), Box::new(e2), s)
 }
@@ -16,9 +14,11 @@ pub fn binary_(op: BinOp, e1: Expr, e2: Expr, s: Pos) -> Expr {
 
 // use default arguments for t.
 pub fn var_(x: &str, e: Expr, s: Pos) -> Stmt {
-    Stmt::Var(x.to_string(), None, e, s)
+    Stmt::Var(x.into(), None, Box::new(e), s)
 }
-
 pub fn block_(stmts: Vec<Stmt>, s: Pos) -> Stmt {
     Stmt::Block(stmts, s)
+}
+pub fn for_in_(bind: Id, container: Expr, body: Stmt, s: Pos) -> Stmt {
+    Stmt::ForIn(bind, Box::new(container), Box::new(body), s)
 }

--- a/libjankscripten/src/jankierscript/from_javascript.rs
+++ b/libjankscripten/src/jankierscript/from_javascript.rs
@@ -1,5 +1,6 @@
 use super::super::javascript::constructors as Js_;
 use super::super::javascript::syntax as Js;
+use super::constructors::*;
 use super::syntax::*;
 use crate::pos::Pos;
 
@@ -66,7 +67,10 @@ fn stmt(s: Js::Stmt) -> Stmt {
             Box::new(stmt(*e)),
             s,
         ),
-        Js::ForIn(_, _, _, _, s) => todo!("for in loops"),
+        Js::ForIn(is_var, bind, container, body, s) => {
+            assert!(!is_var, "for..in was not desugared to not use var");
+            for_in_(bind, expr(*container), stmt(*body), s)
+        }
         Js::Label(x, st, s) => Label(x, Box::new(stmt(*st)), s),
         Js::Break(x, s) => Break(x.unwrap(), s),
         Js::Continue(_, s) => unexpected(&s),

--- a/libjankscripten/src/jankierscript/mod.rs
+++ b/libjankscripten/src/jankierscript/mod.rs
@@ -1,6 +1,5 @@
-#![allow(unused)]
+pub mod constructors;
 mod syntax;
-// pub mod constructors;
 // pub mod inference;
 mod coercion_insertion;
 mod from_javascript;

--- a/libjankscripten/src/jankierscript/syntax.rs
+++ b/libjankscripten/src/jankierscript/syntax.rs
@@ -3,6 +3,7 @@
 //! The JavaScript AST goes through several stages of desugaring before we
 //! produce a program in this language.
 
+pub use crate::javascript::Lit;
 use crate::pos::Pos;
 pub use crate::shared::Id;
 pub use crate::shared::Type;
@@ -18,7 +19,7 @@ pub type BinOp = super::super::javascript::BinaryOp;
 
 #[derive(Debug)]
 pub enum Expr {
-    Lit(super::super::javascript::Lit, Pos),
+    Lit(Lit, Pos),
     Array(Vec<Expr>, Pos),
     Object(Vec<(super::super::javascript::Key, Expr)>, Pos),
     Id(Id, Pos),
@@ -39,6 +40,13 @@ pub enum Stmt {
     Empty,
     If(Box<Expr>, Box<Stmt>, Box<Stmt>, Pos),
     Loop(Box<Stmt>, Pos),
+    /// TODO(luna):
+    /// 1. make sure the bool from javascript has been successfully
+    ///    desugared
+    /// 2. wouldn't it be nice if there was like, a ForInEntries Expr (or even
+    ///    __JNKS.forInEntries) and we could desugar this to loop? because
+    ///    doing this to jankyscript and notwasm stuff is going to be annoying
+    ForIn(Id, Box<Expr>, Box<Stmt>, Pos),
     Label(Id, Box<Stmt>, Pos),
     Break(Id, Pos),
     Catch(Box<Stmt>, Id, Box<Stmt>, Pos),

--- a/libjankscripten/src/jankyscript/compile.rs
+++ b/libjankscripten/src/jankyscript/compile.rs
@@ -10,8 +10,6 @@ where
     F: FnOnce(&Stmt) -> (),
 {
     type_check(janky_ast)?;
-    eprintln!("TODO(luna): REMOVE THIS LINE. IT'S FOR DEBUGGING 'JUST GET TYPE CHECK TO WORK'");
-    std::process::exit(0);
     // TODO(luna): maybe the runtime should be added in jankierscript or
     // jankyscript. this would mean we could assert free_vars == \emptyset
     free_vars(janky_ast);

--- a/libjankscripten/src/jankyscript/compile.rs
+++ b/libjankscripten/src/jankyscript/compile.rs
@@ -10,6 +10,8 @@ where
     F: FnOnce(&Stmt) -> (),
 {
     type_check(janky_ast)?;
+    eprintln!("TODO(luna): REMOVE THIS LINE. IT'S FOR DEBUGGING 'JUST GET TYPE CHECK TO WORK'");
+    std::process::exit(0);
     // TODO(luna): maybe the runtime should be added in jankierscript or
     // jankyscript. this would mean we could assert free_vars == \emptyset
     free_vars(janky_ast);

--- a/libjankscripten/src/jankyscript/constructors.rs
+++ b/libjankscripten/src/jankyscript/constructors.rs
@@ -88,6 +88,10 @@ pub fn loop_(body: Stmt, s: Pos) -> Stmt {
     Stmt::Loop(Box::new(body), s)
 }
 
+pub fn for_in_(bind: Id, container: Expr, body: Stmt, s: Pos) -> Stmt {
+    Stmt::ForIn(bind, Box::new(container), Box::new(body), s)
+}
+
 pub fn empty_() -> Stmt {
     Stmt::Empty
 }

--- a/libjankscripten/src/jankyscript/fv.rs
+++ b/libjankscripten/src/jankyscript/fv.rs
@@ -42,6 +42,20 @@ fn var_summary(stmt: &mut Stmt) -> (IdMap, IdMap) {
             )
         }
         Loop(s, _) => var_summary(s),
+        ForIn(bind, container, body, _) => {
+            let (declared_in_body, referenced_in_body) = var_summary(body);
+            let referenced_in_container = fv_expr(container);
+            // TODO(luna): this is a guess based on how variable lifting
+            // interacts with coercion_insertion but it's not really a proper
+            // way to do things. maybe for..in needs a type field?
+            let referenced_in_bind = IdMap::unit(bind.clone(), Type::Any);
+            (
+                declared_in_body,
+                referenced_in_body
+                    .union(referenced_in_container)
+                    .union(referenced_in_bind),
+            )
+        }
         Break(_, _) => (empty(), empty()),
         Catch(body, exn_name, catch_body, _) => {
             let (declared_in_body, referenced_in_body) = var_summary(body);

--- a/libjankscripten/src/jankyscript/pretty.rs
+++ b/libjankscripten/src/jankyscript/pretty.rs
@@ -298,6 +298,14 @@ impl Pretty for Stmt {
                 pp.hardline(),
             ),
             Stmt::Loop(s, _) => pp.concat(vec![pp.text("loop"), pp.hardline(), s.pretty(pp)]),
+            Stmt::ForIn(bind, container, body, _) => pp
+                .text("for (")
+                .append(pp.as_string(bind))
+                .append(pp.text(" in "))
+                .append(container.pretty(pp))
+                .append(pp.text(")"))
+                .append(pp.line())
+                .append(body.pretty(pp)),
             Stmt::Label(lbl, s, _) => pp.concat(vec![
                 pp.as_string(lbl),
                 pp.text(":"),

--- a/libjankscripten/src/jankyscript/syntax.rs
+++ b/libjankscripten/src/jankyscript/syntax.rs
@@ -120,6 +120,7 @@ pub enum Stmt {
     Expr(Box<Expr>, Pos),
     If(Box<Expr>, Box<Stmt>, Box<Stmt>, Pos),
     Loop(Box<Stmt>, Pos),
+    ForIn(Id, Box<Expr>, Box<Stmt>, Pos),
     Label(Id, Box<Stmt>, Pos),
     Break(Id, Pos),
     Catch(Box<Stmt>, Id, Box<Stmt>, Pos),

--- a/libjankscripten/src/jankyscript/syntax.rs
+++ b/libjankscripten/src/jankyscript/syntax.rs
@@ -22,9 +22,8 @@ impl BinaryOp {
             PtrEq => (Type::Any, Type::Bool), // for completeness; should be special-cased
             I32Eq | I32Ne | I32GT | I32LT | I32Ge | I32Le => (Type::Int, Type::Bool),
             F64Eq | F64Ne | F64LT | F64GT | F64Ge | F64Le => (Type::Float, Type::Bool),
-            I32Add | I32Sub | I32Mul | I32Div | I32Rem | I32And | I32Or | I32Shl | I32Shr => {
-                (Type::Int, Type::Int)
-            }
+            I32Add | I32Sub | I32Mul | I32Div | I32Rem | I32And | I32Or | I32Xor | I32Shl
+            | I32Shr => (Type::Int, Type::Int),
             F64Add | F64Sub | F64Mul | F64Div => (Type::Float, Type::Float),
         }
     }

--- a/libjankscripten/src/jankyscript/syntax.rs
+++ b/libjankscripten/src/jankyscript/syntax.rs
@@ -23,7 +23,7 @@ impl BinaryOp {
             I32Eq | I32Ne | I32GT | I32LT | I32Ge | I32Le => (Type::Int, Type::Bool),
             F64Eq | F64Ne | F64LT | F64GT | F64Ge | F64Le => (Type::Float, Type::Bool),
             I32Add | I32Sub | I32Mul | I32Div | I32Rem | I32And | I32Or | I32Xor | I32Shl
-            | I32Shr => (Type::Int, Type::Int),
+            | I32Shr | I32ShrU => (Type::Int, Type::Int),
             F64Add | F64Sub | F64Mul | F64Div => (Type::Float, Type::Float),
         }
     }

--- a/libjankscripten/src/jankyscript/type_checking.rs
+++ b/libjankscripten/src/jankyscript/type_checking.rs
@@ -169,6 +169,19 @@ fn type_check_stmt(stmt: &Stmt, env: Env, ret_ty: &Option<Type>) -> TypeChecking
 
             Ok(env)
         }
+        Stmt::ForIn(bind, container, body, s) => {
+            ensure_indexable(
+                "for..in",
+                type_check_expr(container, env.clone())?,
+                s.clone(),
+            )?;
+            // type check body in a new scope
+            // TODO(luna): like in jankyscript::fv, this is a guess, and ForIn
+            // should really have a type
+            let for_in_env = env.clone().update(bind.clone(), Type::Any);
+            type_check_stmt(&body, for_in_env, ret_ty)?;
+            Ok(env)
+        }
         Stmt::Throw(e, _) => {
             // expression we're throwing should be well-typed
             type_check_expr(&e, env.clone())?;

--- a/libjankscripten/src/jankyscript/type_checking.rs
+++ b/libjankscripten/src/jankyscript/type_checking.rs
@@ -544,7 +544,6 @@ fn type_check_lit(l: &Lit) -> Type {
         Lit::Num(Num::Float(_)) => Type::Float,
         Lit::Num(Num::Int(_)) => Type::Int,
         Lit::Undefined => Type::Any,
-        _ => todo!("regex"),
-        // Regex(String, String), // TODO(arjun): The Regex is not properly parsed
+        Lit::Regex(_, _) => Type::Any,
     }
 }

--- a/libjankscripten/src/jankyscript/walk.rs
+++ b/libjankscripten/src/jankyscript/walk.rs
@@ -195,6 +195,12 @@ where
                 let loc = Loc::Node(Context::Stmt, loc);
                 self.walk_expr(a, &loc);
             }
+            // 1xExpr, 1xStmt
+            ForIn(_, e, s, _) => {
+                let loc = Loc::Node(Context::Stmt, loc);
+                self.walk_expr(e, &loc);
+                self.walk_stmt(s, &loc);
+            }
             // 1xExpr, 2xStmt
             If(e, sa, sb, _) => {
                 let loc = Loc::Node(Context::Stmt, loc);

--- a/libjankscripten/src/javascript/constructors.rs
+++ b/libjankscripten/src/javascript/constructors.rs
@@ -87,6 +87,10 @@ pub fn str_(st: impl Into<String>, s: Pos) -> Expr {
     Expr::Lit(Lit::String(st.into()), s)
 }
 
+pub fn int_(i: i32, s: Pos) -> Expr {
+    Expr::Lit(Lit::Num(Num::Int(i)), s)
+}
+
 pub fn id_<I: Into<Id>>(id: I, s: Pos) -> Expr {
     Expr::Id(id.into(), s)
 }

--- a/libjankscripten/src/javascript/desugar.rs
+++ b/libjankscripten/src/javascript/desugar.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub fn desugar(stmt: &mut Stmt, ng: &mut NameGen) {
     stmt.walk(&mut super::desugar_function_stmts::DesugarFunctionStmts {});
+    normalize_std_lib_calls::normalize_std_lib_calls(stmt);
     desugar_switch::desugar_switch(stmt, ng);
     // dep: desugar_switch
     desugar_loops::desugar_loops(stmt, ng);

--- a/libjankscripten/src/javascript/desugar.rs
+++ b/libjankscripten/src/javascript/desugar.rs
@@ -14,7 +14,7 @@ pub fn desugar(stmt: &mut Stmt, ng: &mut NameGen) {
     // dep: desugar_vardecls
     // we want this to go sooner rather than later to reduce anys
     lift_vars::lift_vars(stmt);
-    // dep: add_blocks
+    // dep: add_blocks, normalize_std_lib_calls
     desugar_this::desugar_this(stmt, ng);
     // accesses are immediately applied
     // dep: desugar_this, add_blocks

--- a/libjankscripten/src/javascript/lift_vars.rs
+++ b/libjankscripten/src/javascript/lift_vars.rs
@@ -11,13 +11,22 @@ struct LiftVars;
 
 impl Visitor for LiftVars {
     fn exit_stmt(&mut self, stmt: &mut Stmt, loc: &Loc) {
-        if let Stmt::VarDecl(decl, s) = stmt {
-            let decl1 = decl.pop().expect("no decls in vardecl");
-            assert_eq!(decl.pop(), None, "vardecls not desugared");
-            let new_decl = vardecl1_(decl1.name.clone(), UNDEFINED_, s.clone());
-            loc.body_of_enclosing_function_or_program()
-                .insert(0, new_decl);
-            *stmt = expr_(assign_(decl1.name, *decl1.named, s.clone()), s.clone());
+        match stmt {
+            Stmt::VarDecl(decl, s) => {
+                let decl1 = decl.pop().expect("no decls in vardecl");
+                assert_eq!(decl.pop(), None, "vardecls not desugared");
+                let new_decl = vardecl1_(decl1.name.clone(), UNDEFINED_, s.clone());
+                loc.body_of_enclosing_function_or_program()
+                    .insert(0, new_decl);
+                *stmt = expr_(assign_(decl1.name, *decl1.named, s.clone()), s.clone());
+            }
+            Stmt::ForIn(is_var, bind, container, _, s) if *is_var => {
+                let new_decl = vardecl1_(bind.clone(), container.take(), s.clone());
+                let block_context = loc.body_of_enclosing_function_or_program();
+                block_context.insert(block_context.index, new_decl);
+                *is_var = false;
+            }
+            _ => (),
         }
     }
 }

--- a/libjankscripten/src/javascript/mod.rs
+++ b/libjankscripten/src/javascript/mod.rs
@@ -14,6 +14,7 @@ mod desugar_this;
 mod desugar_updates;
 mod desugar_vardecls;
 mod lift_vars;
+mod normalize_std_lib_calls;
 mod parser;
 pub mod syntax;
 pub mod walk;

--- a/libjankscripten/src/javascript/normalize_std_lib_calls.rs
+++ b/libjankscripten/src/javascript/normalize_std_lib_calls.rs
@@ -1,0 +1,35 @@
+//! it would be really weird if you made a function called parseInt, so i think
+//! it's fair to say that if you call a function called parseInt you're calling the
+//! library function global.parseInt. the trouble is, parseInt is one function that
+//! is very commonly called with the wrong number of arguments. so, we normalize
+//! its using using these assumptions hereuse super::constructors::*;
+use super::constructors::*;
+use super::syntax::*;
+use super::*;
+
+struct NormalizeStdLibCalls;
+
+impl Visitor for NormalizeStdLibCalls {
+    fn exit_expr(&mut self, expr: &mut Expr, loc: &Loc) {
+        match expr {
+            Expr::Call(f, args, s) => {
+                if let Expr::Id(Id::Named(id), _) = &**f {
+                    if &*id == "parseInt" {
+                        match args.len() {
+                            // default radix of 10
+                            1 => args.push(int_(10, s.clone())),
+                            // perfect already
+                            2 => (),
+                            got => panic!("why was parseInt given {} arguments", got),
+                        }
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+pub fn normalize_std_lib_calls(program: &mut Stmt) {
+    program.walk(&mut NormalizeStdLibCalls);
+}

--- a/libjankscripten/src/javascript/parser.rs
+++ b/libjankscripten/src/javascript/parser.rs
@@ -709,7 +709,7 @@ fn parse_lit(lit: swc::Lit, source_map: &Rc<SourceMap>) -> ParseResult<(S::Lit, 
             unsupported_message("big int literal", span, source_map)
         }
         Regex(swc::Regex { exp, flags, span }) => {
-            unsupported_message("regex not yet supported", span, source_map)
+            Ok((S::Lit::Regex(exp.to_string(), flags.to_string()), span))
         }
         JSXText(swc::JSXText { span, .. }) => {
             unsupported_message("jsx string literal", span, source_map)

--- a/libjankscripten/src/notwasm/from_jankyscript.rs
+++ b/libjankscripten/src/notwasm/from_jankyscript.rs
@@ -513,6 +513,7 @@ fn compile_stmt<'a>(state: &'a mut S, stmt: J::Stmt) -> Rope<Stmt> {
             Stmt::Block(compile_stmt(state, *body).into_iter().collect(), p.clone()),
             p,
         )),
+        S::ForIn(..) => todo!("for..in in notwasm"),
         S::Label(x, body, p) => Rope::singleton(label_(
             Label::Named(x.to_pretty(80)),
             Stmt::Block(compile_stmt(state, *body).into_iter().collect(), p.clone()),

--- a/libjankscripten/src/notwasm/pretty.rs
+++ b/libjankscripten/src/notwasm/pretty.rs
@@ -91,6 +91,7 @@ impl Pretty for BinaryOp {
             BinaryOp::I32Rem => pp.text("%"),
             BinaryOp::I32Shl => pp.text("<<"),
             BinaryOp::I32Shr => pp.text(">>"),
+            BinaryOp::I32ShrU => pp.text(">>>"),
             BinaryOp::F64Eq => pp.text("==="),
             BinaryOp::F64Ne => pp.text("!="),
             BinaryOp::F64Add => pp.text("+"),

--- a/libjankscripten/src/notwasm/pretty.rs
+++ b/libjankscripten/src/notwasm/pretty.rs
@@ -86,6 +86,7 @@ impl Pretty for BinaryOp {
             BinaryOp::I32Le => pp.text("<="),
             BinaryOp::I32And => pp.text("&"),
             BinaryOp::I32Or => pp.text("|"),
+            BinaryOp::I32Xor => pp.text("^"),
             BinaryOp::I32Div => pp.text("/"),
             BinaryOp::I32Rem => pp.text("%"),
             BinaryOp::I32Shl => pp.text("<<"),

--- a/libjankscripten/src/notwasm/syntax.rs
+++ b/libjankscripten/src/notwasm/syntax.rs
@@ -125,6 +125,7 @@ pub enum BinaryOp {
     I32Le,
     I32And,
     I32Or,
+    I32Xor,
     I32Shl,
     I32Shr,
     F64Add,

--- a/libjankscripten/src/notwasm/syntax.rs
+++ b/libjankscripten/src/notwasm/syntax.rs
@@ -128,6 +128,7 @@ pub enum BinaryOp {
     I32Xor,
     I32Shl,
     I32Shr,
+    I32ShrU,
     F64Add,
     F64Sub,
     F64Mul,

--- a/libjankscripten/src/notwasm/translation.rs
+++ b/libjankscripten/src/notwasm/translation.rs
@@ -556,6 +556,7 @@ impl<'a> Translate<'a> {
             NO::I32Rem => self.out.push(I32RemS),
             NO::I32And => self.out.push(I32And),
             NO::I32Or => self.out.push(I32Or),
+            NO::I32Xor => self.out.push(I32Xor),
             NO::I32Shl => self.out.push(I32Shl),
             NO::I32Shr => self.out.push(I32ShrS),
             NO::F64Add => self.out.push(F64Add),

--- a/libjankscripten/src/notwasm/translation.rs
+++ b/libjankscripten/src/notwasm/translation.rs
@@ -559,6 +559,7 @@ impl<'a> Translate<'a> {
             NO::I32Xor => self.out.push(I32Xor),
             NO::I32Shl => self.out.push(I32Shl),
             NO::I32Shr => self.out.push(I32ShrS),
+            NO::I32ShrU => self.out.push(I32ShrU),
             NO::F64Add => self.out.push(F64Add),
             NO::F64Sub => self.out.push(F64Sub),
             NO::F64Mul => self.out.push(F64Mul),

--- a/libjankscripten/src/rts_function.rs
+++ b/libjankscripten/src/rts_function.rs
@@ -30,6 +30,7 @@ pub enum RTSFunction {
     NotEqual,
     InstanceOf,
     In,
+    BitwiseNot,
 }
 
 // The name of a runtime function implementation.
@@ -65,7 +66,8 @@ impl RTSFunction {
             StrictNotEqual => Rust("janky_strict_not_equal"),
             NotEqual => Rust("janky_not_equal"),
             InstanceOf => Rust("instance_of"),
-            In => Rust("janky_in"),
+            In => todo!("janky_in"),
+            BitwiseNot => todo!("janky_not"),
         }
     }
 
@@ -107,6 +109,7 @@ impl RTSFunction {
             StrictEqual | Equal | StrictNotEqual | NotEqual | In => {
                 Function(vec![Any, Any], Box::new(Bool))
             }
+            BitwiseNot => Function(vec![Int], Box::new(Int)),
         }
     }
 }
@@ -135,6 +138,7 @@ impl std::fmt::Display for RTSFunction {
                 NotEqual => "!=",
                 InstanceOf => "instanceof",
                 In => "in",
+                BitwiseNot => "~",
             }
         )
     }

--- a/libjankscripten/src/rts_function.rs
+++ b/libjankscripten/src/rts_function.rs
@@ -29,6 +29,7 @@ pub enum RTSFunction {
     StrictNotEqual,
     NotEqual,
     InstanceOf,
+    In,
 }
 
 // The name of a runtime function implementation.
@@ -64,6 +65,7 @@ impl RTSFunction {
             StrictNotEqual => Rust("janky_strict_not_equal"),
             NotEqual => Rust("janky_not_equal"),
             InstanceOf => Rust("instance_of"),
+            In => Rust("janky_in"),
         }
     }
 
@@ -102,7 +104,7 @@ impl RTSFunction {
             Plus | Minus | Times | Mod => Function(vec![Any, Any], Box::new(Any)),
             Over => Function(vec![Any, Any], Box::new(Float)),
             ModF64 => Function(vec![Float, Float], Box::new(Float)),
-            StrictEqual | Equal | StrictNotEqual | NotEqual => {
+            StrictEqual | Equal | StrictNotEqual | NotEqual | In => {
                 Function(vec![Any, Any], Box::new(Bool))
             }
         }
@@ -132,6 +134,7 @@ impl std::fmt::Display for RTSFunction {
                 StrictNotEqual => "!==",
                 NotEqual => "!=",
                 InstanceOf => "instanceof",
+                In => "in",
             }
         )
     }

--- a/libjankscripten/src/rts_function.rs
+++ b/libjankscripten/src/rts_function.rs
@@ -66,8 +66,8 @@ impl RTSFunction {
             StrictNotEqual => Rust("janky_strict_not_equal"),
             NotEqual => Rust("janky_not_equal"),
             InstanceOf => Rust("instance_of"),
-            In => todo!("janky_in"),
-            BitwiseNot => todo!("janky_not"),
+            In => Rust("janky_in"),
+            BitwiseNot => Rust("janky_not"),
         }
     }
 

--- a/libjankscripten/src/shared/std_lib.rs
+++ b/libjankscripten/src/shared/std_lib.rs
@@ -119,7 +119,9 @@ pub fn get_global_object() -> BindMap {
     insert(m, "isNaN", Any);
     insert(m, "parseFloat", Any);
     // i think this specifies before closure conversion but after this-conversion
-    insert(m, "parseInt", Function(vec![Any, Any], Box::new(Any)));
+    // this always accepts the radix, which is normalized in
+    // javascript::normalize_std_lib_calls
+    insert(m, "parseInt", Function(vec![Any, Any, Any], Box::new(Any)));
     // constants
     insert(m, "undefined", Any);
     insert(m, "null", Any);

--- a/libjankscripten/src/shared/std_lib.rs
+++ b/libjankscripten/src/shared/std_lib.rs
@@ -56,6 +56,8 @@ pub fn get_global_object() -> BindMap {
     insert(m, "confirm", Any);
     insert(m, "setTimeout", Any);
     insert(m, "stop", Any);
+    // pyjs
+    insert(m, "alert", Any);
 
     // Built-in objects
     // ----------------

--- a/libjankscripten/src/shared/std_lib.rs
+++ b/libjankscripten/src/shared/std_lib.rs
@@ -58,6 +58,8 @@ pub fn get_global_object() -> BindMap {
     insert(m, "stop", Any);
     // pyjs
     insert(m, "alert", Any);
+    // pyjs
+    insert(m, "document", Any);
 
     // Built-in objects
     // ----------------

--- a/runtime/src/ops.rs
+++ b/runtime/src/ops.rs
@@ -98,6 +98,10 @@ pub extern "C" fn janky_delete(_a: Any, _b: Any) -> bool {
 pub extern "C" fn janky_void(_: Any) -> Any {
     AnyEnum::Undefined.into()
 }
+#[no_mangle]
+pub extern "C" fn janky_not(a: i32) -> i32 {
+    !a
+}
 
 #[no_mangle]
 pub extern "C" fn instance_of(a: Any, b: Any) -> bool {
@@ -166,6 +170,11 @@ fn inclusive_instance_of(obj: ObjectPtr, should_match: ObjectPtr) -> bool {
             false
         }
     }
+}
+
+#[no_mangle]
+pub extern "C" fn janky_in(a: Any, b: Any) -> bool {
+    log_panic!("TODO(luna): janky_in");
 }
 
 fn typeof_as_str(a: Any) -> &'static str {

--- a/stdlib.notwasm
+++ b/stdlib.notwasm
@@ -53,7 +53,9 @@ import closure_func: (clos () -> void) -> () -> void;
 
 // here's some standard library stuff!!
 // most of these take Env, Any which is _env, _this (usually ignored)
-import parse_int : (env, any, any) -> any;
+// note this is normalized to always accept the radix by
+// javascript::normalize_std_lib_calls
+import parse_int : (env, any, any, any) -> any;
 // returns 5 for now because void messiness remains
 import console_log : (env, any, any) -> any;
 // math
@@ -97,8 +99,8 @@ var Math: DynObject;
 var global: DynObject;
 var console: DynObject;
 var __JNKS: DynObject;
-// (_, _this, what) -> i32 or f64(NaN)
-var parseInt: clos(env, any, any) -> any;
+// (_, _this, what, radix) -> i32 or f64(NaN)
+var parseInt: clos(env, any, any, any) -> any;
 // temporary Error ground to see other compile-time errors (unrelated to this
 // being called Error)
 var Error: clos(env, any, any) -> any;


### PR DESCRIPTION
All benchmarks except clojurescript and dart now at least pass through the first jankyscript typecheck (before closure conversion) before they blow up. This means that:

- Regex program and flags are passed through JankyScript and given the type of Any
- ForIn is passed through JankyScript and (messily) typechecked
- Xor, UnsignedRightShift, and Unary + are supported
- `alert` and `document` are added to the standard library types table
- `typeof nonExist` is handled correctly
- `nonExist` is turned into `undefined` with a very large warning
- any function called `parseInt` or `Error`, when called with missing arguments, is normalized with their "defaults"
- `delete`, unary `~', and `in` are typechecked (but not supported)
- `nonExist = 5` becomes `undefined` with a huge warning