### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Node. Follow these steps to install the prerequisites:
         rustup target add wasm32-unknown-unknown
 
 4.  Install the Wasm-Bindgen CLI, to allow Rust unit tests to run in
-    WebAssembly:
+    WebAssembly (at moment we require version 0.2.68):
     
-        cargo install wasm-bindgen-cli
+        cargo install --version 0.2.68 wasm-bindgen-cli
 
 5.  On Ubuntu Linux, install *libssl* and *pkg-config*:
     


### PR DESCRIPTION
Hi Arjun,

While following the build instructions I stumble upon an error, which appears to be due to installing an incompatible version of `wasm-bindgen-cli`. This patch updates the build instructions to fix the version of `wasm-bindgen-cli` to version *0.2.68*. I suppose you might later want to dispense of this restriction.